### PR TITLE
Removed self loops from WattsStrogatz graph model

### DIFF
--- a/Data/Graph/Generators/Random/WattsStrogatz.hs
+++ b/Data/Graph/Generators/Random/WattsStrogatz.hs
@@ -110,7 +110,7 @@ wattsStrogatzGraph gen n k p = do
     rewrite (i, j1) edges = do
       r <- uniform gen :: IO Double
       let j2 = floor $ r*((fromInteger.toInteger) n)
-      if (member (i, j2) edges || member (j2, i) edges)
+      if (((member (i, j2) edges) || (member (j2, i) edges)) || (i == j2)) 
         then rewrite (i, j1) edges
         else return $ swap (i, j1) (i, j2) edges
 


### PR DESCRIPTION
Watts Strogatz model for graph generation does not contain any self loops. This property has been addressed in the change made in commit to remove any possibility of self loop generation.